### PR TITLE
[imp] better naming for HasInstances methods. Fixes #4

### DIFF
--- a/src/Categories/Category.php
+++ b/src/Categories/Category.php
@@ -106,7 +106,7 @@ class Category extends ComponentEntity implements Publishable
 		$categories = array_map(
 			function ($item)
 			{
-				return static::instance($item->id)->bind($item);
+				return static::find($item->id)->bind($item);
 			},
 			$db->loadObjectList() ?: array()
 		);

--- a/src/Categories/Traits/HasCategory.php
+++ b/src/Categories/Traits/HasCategory.php
@@ -72,7 +72,7 @@ trait HasCategory
 
 		if (array_key_exists($column, $data))
 		{
-			return Category::instance($data[$column]);
+			return Category::find($data[$column]);
 		}
 
 		return new Category;

--- a/src/Content/Article.php
+++ b/src/Content/Article.php
@@ -131,7 +131,7 @@ class Article extends ComponentEntity implements Aclable, Ownerable, Publishable
 
 		if (array_key_exists($column, $data))
 		{
-			return Category::instance($data[$column]);
+			return Category::find($data[$column]);
 		}
 
 		return new Category;
@@ -175,7 +175,7 @@ class Article extends ComponentEntity implements Aclable, Ownerable, Publishable
 		$tags = array_map(
 			function ($tag)
 			{
-				return Tag::instance($tag->id)->bind($tag);
+				return Tag::find($tag->id)->bind($tag);
 			},
 			$items
 		);
@@ -204,7 +204,7 @@ class Article extends ComponentEntity implements Aclable, Ownerable, Publishable
 		$articles = array_map(
 			function ($item)
 			{
-				return static::instance($item->id)->bind($item);
+				return static::find($item->id)->bind($item);
 			},
 			$this->getArticlesModel($state)->getItems() ?: array()
 		);

--- a/src/Content/Category.php
+++ b/src/Content/Category.php
@@ -46,7 +46,7 @@ class Category extends BaseCategory implements Aclable
 		$articles = array_map(
 			function ($item)
 			{
-				return Article::instance($item->id)->bind($item);
+				return Article::find($item->id)->bind($item);
 			},
 			$this->getArticlesModel()->getItems() ?: array()
 		);
@@ -92,7 +92,7 @@ class Category extends BaseCategory implements Aclable
 		$tags = array_map(
 			function ($tag)
 			{
-				return Tag::instance($tag->id)->bind($tag);
+				return Tag::find($tag->id)->bind($tag);
 			},
 			$items
 		);

--- a/src/Content/Traits/HasArticle.php
+++ b/src/Content/Traits/HasArticle.php
@@ -82,7 +82,7 @@ trait HasArticle
 
 		if (array_key_exists($column, $data))
 		{
-			return Article::instance($data[$column]);
+			return Article::find($data[$column]);
 		}
 
 		return new Article;

--- a/src/Core/Extension/Component.php
+++ b/src/Core/Extension/Component.php
@@ -95,7 +95,7 @@ class Component extends Extension implements Aclable
 
 		if (isset(self::$optionIdXref[$option]))
 		{
-			return self::instance(static::$optionIdXref[$option]);
+			return self::find(static::$optionIdXref[$option]);
 		}
 
 		$component = new static;
@@ -108,7 +108,7 @@ class Component extends Extension implements Aclable
 
 		static::$optionIdXref[$option] = (int) $table->extension_id;
 
-		return self::instance($table->extension_id)->bind($table->getProperties(true));
+		return self::find($table->extension_id)->bind($table->getProperties(true));
 	}
 
 	/**

--- a/src/Core/Traits/HasAsset.php
+++ b/src/Core/Traits/HasAsset.php
@@ -79,6 +79,6 @@ trait HasAsset
 			$assetId = 0;
 		}
 
-		return $assetId ? Asset::instance($assetId) : new Asset;
+		return $assetId ? Asset::find($assetId) : new Asset;
 	}
 }

--- a/src/Core/Traits/HasInstances.php
+++ b/src/Core/Traits/HasInstances.php
@@ -31,7 +31,7 @@ trait HasInstances
 	 *
 	 * @return  void
 	 */
-	public static function clearInstance($id)
+	public static function clear($id)
 	{
 		unset(static::$instances[get_called_class()][$id]);
 	}
@@ -41,7 +41,7 @@ trait HasInstances
 	 *
 	 * @return  void
 	 */
-	public static function clearAllInstances()
+	public static function clearAll()
 	{
 		unset(static::$instances[get_called_class()]);
 	}
@@ -53,11 +53,11 @@ trait HasInstances
 	 *
 	 * @return  $this
 	 */
-	public static function freshInstance($id)
+	public static function fresh($id)
 	{
-		static::clearInstance($id);
+		static::clear($id);
 
-		return static::instance($id);
+		return static::find($id);
 	}
 
 	/**
@@ -67,7 +67,7 @@ trait HasInstances
 	 *
 	 * @return  $this
 	 */
-	public static function instance($id)
+	public static function find($id)
 	{
 		$class = get_called_class();
 

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -405,7 +405,7 @@ abstract class Entity implements EntityInterface
 	 */
 	public static function load($id)
 	{
-		return static::instance($id)->fetch();
+		return static::find($id)->fetch();
 	}
 
 	/**

--- a/src/Fields/Traits/HasFields.php
+++ b/src/Fields/Traits/HasFields.php
@@ -159,7 +159,7 @@ trait HasFields
 			array_map(
 				function ($field)
 				{
-					return Field::instance($field->id)->bind($field);
+					return Field::find($field->id)->bind($field);
 				},
 				$this->getFieldsThroughHelper($this->fieldsContext())
 			)

--- a/src/Users/Traits/HasAuthor.php
+++ b/src/Users/Traits/HasAuthor.php
@@ -88,6 +88,6 @@ trait HasAuthor
 	{
 		$authorId = (int) $this->get($this->columnAlias(Column::AUTHOR));
 
-		return User::instance($authorId);
+		return User::find($authorId);
 	}
 }

--- a/src/Users/Traits/HasEditor.php
+++ b/src/Users/Traits/HasEditor.php
@@ -88,6 +88,6 @@ trait HasEditor
 	{
 		$editorId = (int) $this->get($this->columnAlias(Column::EDITOR));
 
-		return User::instance($editorId);
+		return User::find($editorId);
 	}
 }

--- a/src/Users/Traits/HasOwner.php
+++ b/src/Users/Traits/HasOwner.php
@@ -93,6 +93,6 @@ trait HasOwner
 			throw new \InvalidArgumentException($msg);
 		}
 
-		return User::instance($ownerId);
+		return User::find($ownerId);
 	}
 }

--- a/src/Users/Traits/HasUser.php
+++ b/src/Users/Traits/HasUser.php
@@ -103,6 +103,6 @@ trait HasUser
 	{
 		$userId = (int) $this->get($this->columnAlias(Column::USER));
 
-		return User::instance($userId);
+		return User::find($userId);
 	}
 }

--- a/src/Users/User.php
+++ b/src/Users/User.php
@@ -43,7 +43,7 @@ class User extends ComponentEntity implements Aclable
 	{
 		$userId = (int) \JFactory::getUser()->get('id');
 
-		return $userId ? static::instance($userId) : new static;
+		return $userId ? static::find($userId) : new static;
 	}
 
 	/**
@@ -238,7 +238,7 @@ class User extends ComponentEntity implements Aclable
 
 		foreach ($items as $item)
 		{
-			$userGroup = UserGroup::instance($item->id)->bind($item);
+			$userGroup = UserGroup::find($item->id)->bind($item);
 
 			$userGroups->add($userGroup);
 		}

--- a/src/Users/UserGroup.php
+++ b/src/Users/UserGroup.php
@@ -39,7 +39,7 @@ class UserGroup extends ComponentEntity
 		$users = array_map(
 			function ($item)
 			{
-				return User::instance($item->id)->bind($item);
+				return User::find($item->id)->bind($item);
 			},
 			$this->usersModel()->getItems() ?: array()
 		);

--- a/tests/Tests/Categories/CategoryTest.php
+++ b/tests/Tests/Categories/CategoryTest.php
@@ -59,7 +59,7 @@ class CategoryTest extends \TestCaseDatabase
 	 */
 	protected function tearDown()
 	{
-		Category::clearAllInstances();
+		Category::clearAll();
 
 		$this->restoreFactoryState();
 
@@ -156,7 +156,7 @@ class CategoryTest extends \TestCaseDatabase
 
 		$rowProperty->setValue($category, array('id' => 999, 'created_user_id' => 666));
 
-		$this->assertSame(User::instance(666), $category->author());
+		$this->assertSame(User::find(666), $category->author());
 	}
 
 	/**
@@ -174,7 +174,7 @@ class CategoryTest extends \TestCaseDatabase
 
 		$rowProperty->setValue($category, array('id' => 999, 'modified_user_id' => 666));
 
-		$this->assertSame(User::instance(666), $category->editor());
+		$this->assertSame(User::find(666), $category->editor());
 	}
 
 	/**

--- a/tests/Tests/Categories/Traits/HasCategoriesTest.php
+++ b/tests/Tests/Categories/Traits/HasCategoriesTest.php
@@ -27,7 +27,7 @@ class HasCategoriesTest extends \PHPUnit\Framework\TestCase
 	 */
 	protected function tearDown()
 	{
-		ClassWithCategories::clearAllInstances();
+		ClassWithCategories::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/Content/ArticleTest.php
+++ b/tests/Tests/Content/ArticleTest.php
@@ -49,7 +49,7 @@ class ArticleTest extends \TestCaseDatabase
 	 */
 	protected function tearDown()
 	{
-		Article::clearAllInstances();
+		Article::clearAll();
 
 		$this->restoreFactoryState();
 
@@ -121,7 +121,7 @@ class ArticleTest extends \TestCaseDatabase
 	 */
 	public function testAssetCanBeRetrieved()
 	{
-		$article = Article::instance(1);
+		$article = Article::find(1);
 
 		$asset = $article->asset();
 
@@ -144,7 +144,7 @@ class ArticleTest extends \TestCaseDatabase
 
 		$rowProperty->setValue($article, array('id' => 999, 'created_by' => 666));
 
-		$this->assertSame(User::instance(666), $article->author());
+		$this->assertSame(User::find(666), $article->author());
 	}
 
 	/**
@@ -162,7 +162,7 @@ class ArticleTest extends \TestCaseDatabase
 
 		$rowProperty->setValue($article, array('id' => 999, 'modified_by' => 666));
 
-		$this->assertSame(User::instance(666), $article->editor());
+		$this->assertSame(User::find(666), $article->editor());
 	}
 
 	/**
@@ -186,7 +186,7 @@ class ArticleTest extends \TestCaseDatabase
 
 		// No reload = same category
 		$this->assertEquals(new Category, $article->category());
-		$this->assertEquals(Category::instance(666), $article->category(true));
+		$this->assertEquals(Category::find(666), $article->category(true));
 	}
 
 	/**
@@ -310,12 +310,12 @@ class ArticleTest extends \TestCaseDatabase
 
 		$this->assertEquals(array(), $article->getUrls());
 
-		$article = Article::freshInstance(999);
+		$article = Article::fresh(999);
 		$rowProperty->setValue($article, array('id' => 999, 'urls' => '{}'));
 
 		$this->assertEquals(array(), $article->getUrls());
 
-		$article = Article::freshInstance(999);
+		$article = Article::fresh(999);
 		$rowProperty->setValue(
 			$article,
 			array(
@@ -326,7 +326,7 @@ class ArticleTest extends \TestCaseDatabase
 
 		$this->assertEquals(array(), $article->getUrls());
 
-		$article = Article::freshInstance(999);
+		$article = Article::fresh(999);
 		$rowProperty->setValue(
 			$article,
 			array(
@@ -345,7 +345,7 @@ class ArticleTest extends \TestCaseDatabase
 
 		$this->assertEquals($expected, $article->getUrls());
 
-		$article = Article::freshInstance(999);
+		$article = Article::fresh(999);
 		$rowProperty->setValue(
 			$article,
 			array(
@@ -391,7 +391,7 @@ class ArticleTest extends \TestCaseDatabase
 
 		$this->assertFalse($article->hasFullTextImage());
 
-		$article = Article::freshInstance(999);
+		$article = Article::fresh(999);
 		$rowProperty->setValue(
 			$article,
 			array(
@@ -402,12 +402,12 @@ class ArticleTest extends \TestCaseDatabase
 
 		$this->assertTrue($article->hasFullTextImage());
 
-		$article = Article::freshInstance(999);
+		$article = Article::fresh(999);
 		$rowProperty->setValue($article, array('id' => 999, 'images' => ''));
 
 		$this->assertFalse($article->hasFullTextImage());
 
-		$article = Article::freshInstance(999);
+		$article = Article::fresh(999);
 		$rowProperty->setValue(
 			$article,
 			array(
@@ -436,7 +436,7 @@ class ArticleTest extends \TestCaseDatabase
 
 		$this->assertFalse($article->hasIntroImage());
 
-		$article = Article::freshInstance(999);
+		$article = Article::fresh(999);
 		$rowProperty->setValue(
 			$article,
 			array(
@@ -447,12 +447,12 @@ class ArticleTest extends \TestCaseDatabase
 
 		$this->assertTrue($article->hasIntroImage());
 
-		$article = Article::freshInstance(999);
+		$article = Article::fresh(999);
 		$rowProperty->setValue($article, array('id' => 999, 'images' => ''));
 
 		$this->assertFalse($article->hasIntroImage());
 
-		$article = Article::freshInstance(999);
+		$article = Article::fresh(999);
 		$rowProperty->setValue(
 			$article,
 			array(

--- a/tests/Tests/Content/CategoryTest.php
+++ b/tests/Tests/Content/CategoryTest.php
@@ -30,7 +30,7 @@ class CategoryTest extends \PHPUnit\Framework\TestCase
 	 */
 	protected function tearDown()
 	{
-		Category::clearAllInstances();
+		Category::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/Content/Traits/HasArticleTest.php
+++ b/tests/Tests/Content/Traits/HasArticleTest.php
@@ -33,7 +33,7 @@ class HasArticleTest extends \PHPUnit\Framework\TestCase
 	 */
 	protected function tearDown()
 	{
-		ClassWithArticle::clearAllInstances();
+		ClassWithArticle::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/Content/Traits/HasArticlesTest.php
+++ b/tests/Tests/Content/Traits/HasArticlesTest.php
@@ -27,7 +27,7 @@ class HasArticlesTest extends \PHPUnit\Framework\TestCase
 	 */
 	protected function tearDown()
 	{
-		ClassWithArticles::clearAllInstances();
+		ClassWithArticles::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/Core/AssetTest.php
+++ b/tests/Tests/Core/AssetTest.php
@@ -24,7 +24,7 @@ class AssetTest extends \TestCase
 	 */
 	public function testInstanceLoadsAnAsset()
 	{
-		$asset = Asset::instance(1);
+		$asset = Asset::find(1);
 
 		$this->assertEquals(1, $asset->id());
 	}

--- a/tests/Tests/Core/Extension/ActiveComponentTest.php
+++ b/tests/Tests/Core/Extension/ActiveComponentTest.php
@@ -44,7 +44,7 @@ class ActiveComponentTest extends \TestCaseDatabase
 	 */
 	protected function tearDown()
 	{
-		ActiveComponent::clearAllInstances();
+		ActiveComponent::clearAll();
 
 		$this->restoreFactoryState();
 

--- a/tests/Tests/Core/Extension/ComponentTest.php
+++ b/tests/Tests/Core/Extension/ComponentTest.php
@@ -44,7 +44,7 @@ class ComponentTest extends \TestCaseDatabase
 	 */
 	protected function tearDown()
 	{
-		Component::clearAllInstances();
+		Component::clearAll();
 
 		$this->restoreFactoryState();
 

--- a/tests/Tests/Core/ExtensionTest.php
+++ b/tests/Tests/Core/ExtensionTest.php
@@ -27,7 +27,7 @@ class ExtensionTest extends \TestCaseDatabase
 	 */
 	protected function tearDown()
 	{
-		Extension::clearAllInstances();
+		Extension::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/Core/Traits/HasAssociationsTest.php
+++ b/tests/Tests/Core/Traits/HasAssociationsTest.php
@@ -26,7 +26,7 @@ class HasAssociationsTest extends \PHPUnit\Framework\TestCase
 	 */
 	protected function tearDown()
 	{
-		EntityWithAssociations::clearAllInstances();
+		EntityWithAssociations::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/Core/Traits/HasClientTest.php
+++ b/tests/Tests/Core/Traits/HasClientTest.php
@@ -34,7 +34,7 @@ class HasClientTest extends \PHPUnit\Framework\TestCase
 	 */
 	protected function tearDown()
 	{
-		ClassWithClient::clearAllInstances();
+		ClassWithClient::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/Core/Traits/HasComponentTest.php
+++ b/tests/Tests/Core/Traits/HasComponentTest.php
@@ -45,7 +45,7 @@ class HasComponentTest extends \TestCaseDatabase
 	 */
 	protected function tearDown()
 	{
-		ClassWithComponent::clearAllInstances();
+		ClassWithComponent::clearAll();
 
 		$this->restoreFactoryState();
 

--- a/tests/Tests/Core/Traits/HasFeaturedTest.php
+++ b/tests/Tests/Core/Traits/HasFeaturedTest.php
@@ -26,7 +26,7 @@ class HasFeaturedTest extends \PHPUnit\Framework\TestCase
 	 */
 	protected function tearDown()
 	{
-		EntityWithFeatured::clearAllInstances();
+		EntityWithFeatured::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/Core/Traits/HasInstancesTest.php
+++ b/tests/Tests/Core/Traits/HasInstancesTest.php
@@ -36,79 +36,79 @@ class HasInstancesTest extends \TestCase
 	}
 
 	/**
-	 * clearAllInstances clears all the instances.
+	 * clearAll clears all the instances.
 	 *
 	 * @return  void
 	 */
-	public function testClearAllInstancesClearsAllTheInstances()
+	public function testClearAllClearsAllTheInstances()
 	{
 		$reflection = new \ReflectionClass(ClassWithInstances::class);
 		$instancesProperty = $reflection->getProperty('instances');
 		$instancesProperty->setAccessible(true);
 
-		$instances = [
-			ClassWithInstances::class => [
+		$instances = array(
+			ClassWithInstances::class => array(
 				1337 => new ClassWithInstances(1337),
 				1338 => new ClassWithInstances(1338)
-			]
-		];
+			)
+		);
 
 		$instancesProperty->setValue(ClassWithInstances::class, $instances);
 
 		$this->assertEquals($instances, $instancesProperty->getValue(ClassWithInstances::class));
 
-		ClassWithInstances::clearAllInstances();
+		ClassWithInstances::clearAll();
 
-		$this->assertEquals([], $instancesProperty->getValue(ClassWithInstances::class));
+		$this->assertEquals(array(), $instancesProperty->getValue(ClassWithInstances::class));
 	}
 
 	/**
-	 * Test clearInstance method.
+	 * Test clear method.
 	 *
 	 * @return  void
 	 */
-	public function testClearInstance()
+	public function testClear()
 	{
-		$class = ClassWithInstances::instance(1337);
+		$class = ClassWithInstances::find(1337);
 		$class->setName('Sample name');
 		$this->assertEquals('Sample name', $class->getName());
 
-		$class2 = ClassWithInstances::instance(1337);
+		$class2 = ClassWithInstances::find(1337);
 		$this->assertEquals('Sample name', $class2->getName());
 
-		ClassWithInstances::clearInstance(1337);
+		ClassWithInstances::clear(1337);
 
-		$class3 = ClassWithInstances::instance(1337);
+		$class3 = ClassWithInstances::find(1337);
 		$this->assertNotEquals('Sample name', $class3->getName());
 	}
 
 	/**
-	 * Test getFreshInstance method.
+	 * Test getFresh method.
 	 *
 	 * @return  void
 	 */
-	public function testFreshInstance()
+	public function testFresh()
 	{
-		$class = ClassWithInstances::instance(1337);
+		$class = ClassWithInstances::find(1337);
 		$class->setName('Sample name');
 		$this->assertEquals('Sample name', $class->getName());
 
-		$class3 = ClassWithInstances::freshInstance(1337);
+		$class3 = ClassWithInstances::fresh(1337);
 		$this->assertNotEquals('Sample name', $class3->getName());
 	}
 
 	/**
-	 * Test getInstance method.
+	 * Test find method.
 	 *
 	 * @return  void
 	 */
-	public function testGetInstance()
+	public function testFind()
 	{
-		$class = ClassWithInstances::instance(1337);
+		$class = ClassWithInstances::find(1337);
 		$class->setName('Sample name');
 		$this->assertEquals('Sample name', $class->getName());
 
-		$class2 = ClassWithInstances::instance(1337);
+		$class2 = ClassWithInstances::find(1337);
 		$this->assertEquals('Sample name', $class2->getName());
 	}
 
@@ -119,14 +119,14 @@ class HasInstancesTest extends \TestCase
 	 */
 	public function testNoCollisionsBetweenClasses()
 	{
-		$class = ClassWithInstances::instance(1337);
+		$class = ClassWithInstances::find(1337);
 		$class->setName('Sample name');
 		$this->assertEquals('Sample name', $class->getName());
 
-		$class2 = AnotherClassWithInstances::instance(1337);
+		$class2 = AnotherClassWithInstances::find(1337);
 		$this->assertNotEquals('Sample name', $class2->getName());
 
-		$class3 = ClassWithInstances::instance(1337);
+		$class3 = ClassWithInstances::find(1337);
 		$this->assertEquals('Sample name', $class3->getName());
 	}
 }

--- a/tests/Tests/Core/Traits/HasPublishDownTest.php
+++ b/tests/Tests/Core/Traits/HasPublishDownTest.php
@@ -32,7 +32,7 @@ class HasPublishDownTest extends \PHPUnit\Framework\TestCase
 	 */
 	protected function tearDown()
 	{
-		EntityWithPublishDown::clearAllInstances();
+		EntityWithPublishDown::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/Core/Traits/HasPublishUpTest.php
+++ b/tests/Tests/Core/Traits/HasPublishUpTest.php
@@ -32,7 +32,7 @@ class HasPublishUpTest extends \PHPUnit\Framework\TestCase
 	 */
 	protected function tearDown()
 	{
-		EntityWithPublishUp::clearAllInstances();
+		EntityWithPublishUp::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/Core/Traits/HasStateTest.php
+++ b/tests/Tests/Core/Traits/HasStateTest.php
@@ -32,7 +32,7 @@ class HasStateTest extends \PHPUnit\Framework\TestCase
 	 */
 	protected function tearDown()
 	{
-		EntityWithState::clearAllInstances();
+		EntityWithState::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/Core/Traits/HasUrlsTest.php
+++ b/tests/Tests/Core/Traits/HasUrlsTest.php
@@ -25,7 +25,7 @@ class HasUrlsTest extends \PHPUnit\Framework\TestCase
 	 */
 	protected function tearDown()
 	{
-		EntityWithUrls::clearAllInstances();
+		EntityWithUrls::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/EntityTest.php
+++ b/tests/Tests/EntityTest.php
@@ -55,7 +55,7 @@ class EntityTest extends \TestCase
 	{
 		$this->restoreFactoryState();
 
-		Entity::clearAllInstances();
+		Entity::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/Fields/FieldTest.php
+++ b/tests/Tests/Fields/FieldTest.php
@@ -28,7 +28,7 @@ class FieldTest extends \TestCaseDatabase
 	 */
 	protected function tearDown()
 	{
-		Field::clearAllInstances();
+		Field::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/Fields/Traits/HasFieldsTest.php
+++ b/tests/Tests/Fields/Traits/HasFieldsTest.php
@@ -27,7 +27,7 @@ class HasFieldsTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testFieldReturnsCorrectField()
 	{
-		$fields = new Collection(array(Field::instance(999), Field::instance(1000)));
+		$fields = new Collection(array(Field::find(999), Field::find(1000)));
 
 		$entity = $this->getMockBuilder(EntityWithFields::class)
 			->setMethods(array('fields'))
@@ -50,7 +50,7 @@ class HasFieldsTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testFieldThrowsExceptionForMissingField()
 	{
-		$fields = new Collection(array(Field::instance(999), Field::instance(1000)));
+		$fields = new Collection(array(Field::find(999), Field::find(1000)));
 
 		$entity = $this->getMockBuilder(EntityWithFields::class)
 			->setMethods(array('fields'))
@@ -104,7 +104,7 @@ class HasFieldsTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testFieldsLoadFields()
 	{
-		$reloadCollection = new Collection(array(Field::instance(999), Field::instance(1000)));
+		$reloadCollection = new Collection(array(Field::find(999), Field::find(1000)));
 
 		$entity = $this->getMockBuilder(EntityWithFields::class)
 			->setMethods(array('loadFields'))
@@ -276,7 +276,7 @@ class HasFieldsTest extends \PHPUnit\Framework\TestCase
 	 */
 	public function testHasFieldReturnsCorrectValue()
 	{
-		$fields = new Collection(array(Field::instance(999), Field::instance(1000)));
+		$fields = new Collection(array(Field::find(999), Field::find(1000)));
 
 		$entity = $this->getMockBuilder(EntityWithFields::class)
 			->setMethods(array('fields'))
@@ -328,6 +328,6 @@ class HasFieldsTest extends \PHPUnit\Framework\TestCase
 		$idProperty->setAccessible(true);
 		$idProperty->setValue($entity, 444);
 
-		$this->assertEquals(new Collection(array(Field::instance(666))), $method->invoke($entity));
+		$this->assertEquals(new Collection(array(Field::find(666))), $method->invoke($entity));
 	}
 }

--- a/tests/Tests/Tags/Traits/HasTagsTest.php
+++ b/tests/Tests/Tags/Traits/HasTagsTest.php
@@ -27,7 +27,7 @@ class HasTagsTest extends \PHPUnit\Framework\TestCase
 	 */
 	protected function tearDown()
 	{
-		ClassWithTags::clearAllInstances();
+		ClassWithTags::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/Translation/Traits/HasTranslationsTest.php
+++ b/tests/Tests/Translation/Traits/HasTranslationsTest.php
@@ -26,7 +26,7 @@ class HasTranslationsTest extends \PHPUnit\Framework\TestCase
 	 */
 	protected function tearDown()
 	{
-		EntityWithTranslations::clearAllInstances();
+		EntityWithTranslations::clearAll();
 
 		parent::tearDown();
 	}
@@ -45,8 +45,8 @@ class HasTranslationsTest extends \PHPUnit\Framework\TestCase
 		$this->assertSame(false, $entity->hasTranslation('pt-BR'));
 
 		$translations = array(
-			'es-ES' => EntityWithTranslations::instance(666),
-			'pt-BR' => EntityWithTranslations::instance(999)
+			'es-ES' => EntityWithTranslations::find(666),
+			'pt-BR' => EntityWithTranslations::find(999)
 		);
 
 		$entity = $this->getMockBuilder(EntityWithTranslations::class)
@@ -75,8 +75,8 @@ class HasTranslationsTest extends \PHPUnit\Framework\TestCase
 
 		$translations = new Collection(
 			array(
-				EntityWithTranslations::instance(666),
-				EntityWithTranslations::instance(999)
+				EntityWithTranslations::find(666),
+				EntityWithTranslations::find(999)
 			)
 		);
 
@@ -99,8 +99,8 @@ class HasTranslationsTest extends \PHPUnit\Framework\TestCase
 	public function testTranslationRetursnCorrectValue()
 	{
 		$translations = array(
-			'es-ES' => EntityWithTranslations::instance(666),
-			'pt-BR' => EntityWithTranslations::instance(999)
+			'es-ES' => EntityWithTranslations::find(666),
+			'pt-BR' => EntityWithTranslations::find(999)
 		);
 
 		$entity = new EntityWithTranslations;
@@ -110,7 +110,7 @@ class HasTranslationsTest extends \PHPUnit\Framework\TestCase
 		$translationsProperty->setAccessible(true);
 		$translationsProperty->setValue($entity, $translations);
 
-		$this->assertSame(EntityWithTranslations::instance(666), $entity->translation('es-ES'));
+		$this->assertSame(EntityWithTranslations::find(666), $entity->translation('es-ES'));
 	}
 
 	/**
@@ -200,8 +200,8 @@ class HasTranslationsTest extends \PHPUnit\Framework\TestCase
 
 		$expected = new Collection(
 			array(
-				EntityWithTranslations::instance(666),
-				EntityWithTranslations::instance(999)
+				EntityWithTranslations::find(666),
+				EntityWithTranslations::find(999)
 			)
 		);
 

--- a/tests/Tests/Translation/TranslatorTest.php
+++ b/tests/Tests/Translation/TranslatorTest.php
@@ -27,7 +27,7 @@ class TranslatorTest extends \TestCase
 	 */
 	protected function tearDown()
 	{
-		Entity::clearAllInstances();
+		Entity::clearAll();
 
 		parent::tearDown();
 	}

--- a/tests/Tests/Users/Traits/HasAuthorTest.php
+++ b/tests/Tests/Users/Traits/HasAuthorTest.php
@@ -148,6 +148,6 @@ class HasAuthorTest extends \PHPUnit\Framework\TestCase
 		$method = $reflection->getMethod('loadAuthor');
 		$method->setAccessible(true);
 
-		$this->assertSame(User::instance(22), $method->invoke($class));
+		$this->assertSame(User::find(22), $method->invoke($class));
 	}
 }

--- a/tests/Tests/Users/Traits/HasEditorTest.php
+++ b/tests/Tests/Users/Traits/HasEditorTest.php
@@ -154,6 +154,6 @@ class HasEditorTest extends \PHPUnit\Framework\TestCase
 		$method = $reflection->getMethod('loadEditor');
 		$method->setAccessible(true);
 
-		$this->assertSame(User::instance(22), $method->invoke($class));
+		$this->assertSame(User::find(22), $method->invoke($class));
 	}
 }

--- a/tests/Tests/Users/Traits/HasOwnerTest.php
+++ b/tests/Tests/Users/Traits/HasOwnerTest.php
@@ -51,7 +51,7 @@ class HasOwnerTest extends \TestCaseDatabase
 	 */
 	protected function tearDown()
 	{
-		EntityWithOwner::clearAllInstances();
+		EntityWithOwner::clearAll();
 
 		$this->restoreFactoryState();
 
@@ -212,7 +212,7 @@ class HasOwnerTest extends \TestCaseDatabase
 		$method = $reflection->getMethod('loadOwner');
 		$method->setAccessible(true);
 
-		$this->assertSame(User::instance(22), $method->invoke($class));
+		$this->assertSame(User::find(22), $method->invoke($class));
 	}
 
 	/**

--- a/tests/Tests/Users/Traits/HasUserGroupsTest.php
+++ b/tests/Tests/Users/Traits/HasUserGroupsTest.php
@@ -35,7 +35,7 @@ class HasUserGroupsTest extends \PHPUnit\Framework\TestCase
 
 		$this->assertSame(null, $userGroupsProperty->getValue($entity));
 
-		$userGroups = new Collection(array(UserGroup::instance(333)));
+		$userGroups = new Collection(array(UserGroup::find(333)));
 
 		$userGroupsProperty->setValue($entity, $userGroups);
 
@@ -62,7 +62,7 @@ class HasUserGroupsTest extends \PHPUnit\Framework\TestCase
 
 		$this->assertSame(null, $userGroupsProperty->getValue($entity));
 
-		$userGroups = new Collection(array(UserGroup::instance(333)));
+		$userGroups = new Collection(array(UserGroup::find(333)));
 
 		$userGroupsProperty->setValue($entity, $userGroups);
 
@@ -78,8 +78,8 @@ class HasUserGroupsTest extends \PHPUnit\Framework\TestCase
 	{
 		$userGroups = new Collection(
 			array(
-				UserGroup::instance(333),
-				UserGroup::instance(666)
+				UserGroup::find(333),
+				UserGroup::find(666)
 			)
 		);
 
@@ -103,8 +103,8 @@ class HasUserGroupsTest extends \PHPUnit\Framework\TestCase
 	{
 		$userGroups = new Collection(
 			array(
-				UserGroup::instance(666),
-				UserGroup::instance(999)
+				UserGroup::find(666),
+				UserGroup::find(999)
 			)
 		);
 
@@ -129,8 +129,8 @@ class HasUserGroupsTest extends \PHPUnit\Framework\TestCase
 	{
 		$userGroups = new Collection(
 			array(
-				UserGroup::instance(333),
-				UserGroup::instance(666)
+				UserGroup::find(333),
+				UserGroup::find(666)
 			)
 		);
 

--- a/tests/Tests/Users/Traits/HasUserTest.php
+++ b/tests/Tests/Users/Traits/HasUserTest.php
@@ -142,6 +142,6 @@ class HasUserTest extends \PHPUnit\Framework\TestCase
 		$method = $reflection->getMethod('loadUser');
 		$method->setAccessible(true);
 
-		$this->assertEquals(User::instance(666), $method->invoke($entity));
+		$this->assertEquals(User::find(666), $method->invoke($entity));
 	}
 }

--- a/tests/Tests/Users/Traits/HasUsersTest.php
+++ b/tests/Tests/Users/Traits/HasUsersTest.php
@@ -35,7 +35,7 @@ class HasUsersTest extends \PHPUnit\Framework\TestCase
 
 		$this->assertSame(null, $usersProperty->getValue($entity));
 
-		$users = new Collection(array(User::instance(333)));
+		$users = new Collection(array(User::find(333)));
 
 		$usersProperty->setValue($entity, $users);
 
@@ -62,7 +62,7 @@ class HasUsersTest extends \PHPUnit\Framework\TestCase
 
 		$this->assertSame(null, $usersProperty->getValue($entity));
 
-		$users = new Collection(array(User::instance(333)));
+		$users = new Collection(array(User::find(333)));
 
 		$usersProperty->setValue($entity, $users);
 
@@ -78,8 +78,8 @@ class HasUsersTest extends \PHPUnit\Framework\TestCase
 	{
 		$users = new Collection(
 			array(
-				User::instance(333),
-				User::instance(666)
+				User::find(333),
+				User::find(666)
 			)
 		);
 
@@ -103,8 +103,8 @@ class HasUsersTest extends \PHPUnit\Framework\TestCase
 	{
 		$users = new Collection(
 			array(
-				User::instance(666),
-				User::instance(999)
+				User::find(666),
+				User::find(999)
 			)
 		);
 
@@ -129,8 +129,8 @@ class HasUsersTest extends \PHPUnit\Framework\TestCase
 	{
 		$users = new Collection(
 			array(
-				User::instance(333),
-				User::instance(666)
+				User::find(333),
+				User::find(666)
 			)
 		);
 

--- a/tests/Tests/Users/UserGroupTest.php
+++ b/tests/Tests/Users/UserGroupTest.php
@@ -46,7 +46,7 @@ class UserGroupTest extends \TestCaseDatabase
 	 */
 	protected function tearDown()
 	{
-		UserGroup::clearAllInstances();
+		UserGroup::clearAll();
 
 		$this->restoreFactoryState();
 

--- a/tests/Tests/Users/UserTest.php
+++ b/tests/Tests/Users/UserTest.php
@@ -47,7 +47,7 @@ class UserTest extends \TestCaseDatabase
 	 */
 	protected function tearDown()
 	{
-		User::clearAllInstances();
+		User::clearAll();
 
 		$this->restoreFactoryState();
 
@@ -111,7 +111,7 @@ class UserTest extends \TestCaseDatabase
 
 		\JFactory::$session = $mockSession;
 
-		$this->assertEquals(User::instance(42), User::active());
+		$this->assertEquals(User::find(42), User::active());
 	}
 
 	/**


### PR DESCRIPTION
In https://github.com/phproberto/joomla-entity/issues/4 @anibalsanchez suggested to change naming to lower the technical knowledge users require to understand what is happening.

This replaces instances methods:

* Use `Article::find(1)` instead of `Article::instance(1)`
* Use `Article::clear(1)` instead of `Article::clearInstance(1)`
* Use `Article::clearAll()` instead of `Article::clearAllInstances()`
* Use `Article::fresh(1)` instead of `Article::freshInstance(1)`

While `find()` maybe be confusing if people thinks it's loading the article it should be ok because lazy loading of data is done transparently for the users. So it's ok to think it's loaded. Also there is no need of something like `findOrFail()` because the `load()` method does exactly that.

So:
* `Article::find(1)` will return an instance pointing to id `1` even if that `1` doesn't really exist.
* `Article::load(1)` will try to load that article with id `1` from static cache and load data from database if needed throwing exceptions if any error happens trying to do it.

Ideally we should always use `find()` to benefit from lazy loading.