### PR TITLE
[imp] avoid throwing an exception in HasOwner because makes ACL harder

### DIFF
--- a/extensions/libraries/joomla_entity/src/Users/Traits/HasOwner.php
+++ b/extensions/libraries/joomla_entity/src/Users/Traits/HasOwner.php
@@ -48,11 +48,14 @@ trait HasOwner
 	 * Check if this entity has an owner.
 	 *
 	 * @return  boolean
-	 *
-	 * @throws  \InvalidArgumentException
 	 */
 	public function hasOwner()
 	{
+		if (!$this->has($this->columnAlias(Column::OWNER)))
+		{
+			return false;
+		}
+
 		return 0 !== (int) $this->get($this->columnAlias(Column::OWNER));
 	}
 

--- a/tests/Unit/Users/Traits/HasOwnerTest.php
+++ b/tests/Unit/Users/Traits/HasOwnerTest.php
@@ -70,8 +70,7 @@ class HasOwnerTest extends \TestCaseDatabase
 			->setMethods(array('columnAlias'))
 			->getMock();
 
-		$class->expects($this->once())
-			->method('columnAlias')
+		$class->method('columnAlias')
 			->willReturn(static::OWNER_COLUMN);
 
 		$reflection = new \ReflectionClass($class);
@@ -88,34 +87,31 @@ class HasOwnerTest extends \TestCaseDatabase
 	}
 
 	/**
-	 * hasOwner throws exception for missing owner column.
+	 * @test
 	 *
-	 * @return  void
-	 *
-	 * @expectedException  \InvalidArgumentException
+	 * @return void
 	 */
-	public function testHasOwnerThrowsExceptionFormissingOwnerColumn()
+	public function hasOwnerReturnFalseWhenNoOwnerColumnExists()
 	{
-		$class = $this->getMockBuilder(EntityWithOwner::class)
+		$entity = $this->getMockBuilder(EntityWithOwner::class)
 			->disableOriginalConstructor()
 			->setMethods(array('columnAlias'))
 			->getMock();
 
-		$class->expects($this->once())
-			->method('columnAlias')
+		$entity->method('columnAlias')
 			->willReturn(static::OWNER_COLUMN);
 
-		$reflection = new \ReflectionClass($class);
+		$reflection = new \ReflectionClass($entity);
 
 		$idProperty = $reflection->getProperty('id');
 		$idProperty->setAccessible(true);
-		$idProperty->setValue($class, 999);
+		$idProperty->setValue($entity, 999);
 
 		$rowProperty = $reflection->getProperty('row');
 		$rowProperty->setAccessible(true);
-		$rowProperty->setValue($class, array('id' => 999));
+		$rowProperty->setValue($entity, array('id' => 999, 'name' => 'Test'));
 
-		$this->assertSame(true, $class->hasOwner());
+		$this->assertFalse($entity->hasOwner());
 	}
 
 	/**


### PR DESCRIPTION
ACL checks perform a lot of ownership tests. There are some special cases where an owner column may not be present but throwing an error is not the best option. 

**Example**

Creating an item but not assigning the owner column (so it doesn't have owner).

```php
$article = new Article;
$article->bind(['title' => 'Hello World', 'catid' => 1]);

// This will throw an exception
if ($this->canCreate())
{
}

$article = new Article;
$article->bind(['title' => 'Hello World', 'catid' => 1, 'created_by' => 22]);

// This won't throw an exception
if ($this->canCreate())
{
}
```
