### PR TITLE
[imp] introduce ViewLevel entity

### DIFF
--- a/extensions/libraries/joomla_entity/src/Users/Traits/HasViewLevels.php
+++ b/extensions/libraries/joomla_entity/src/Users/Traits/HasViewLevels.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Joomla! entity library.
+ *
+ * @copyright  Copyright (C) 2017 Roberto Segura López, Inc. All rights reserved.
+ * @license    See COPYING.txt
+ */
+
+namespace Phproberto\Joomla\Entity\Users\Traits;
+
+defined('_JEXEC') || die;
+
+/**
+ * Trait for entities that have associated view levels.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+trait HasViewLevels
+{
+	/**
+	 * Associated view levels.
+	 *
+	 * @var  Collection
+	 */
+	protected $viewLevels;
+
+	/**
+	 * Clear already loaded view levels.
+	 *
+	 * @return  self
+	 */
+	public function clearViewLevels()
+	{
+		$this->viewLevels = null;
+
+		return $this;
+	}
+
+	/**
+	 * Get the associated view levels.
+	 *
+	 * @return  Collection
+	 */
+	public function viewLevels()
+	{
+		if (null === $this->viewLevels)
+		{
+			$this->viewLevels = $this->loadViewLevels();
+		}
+
+		return $this->viewLevels;
+	}
+
+	/**
+	 * Check if this entity has an associated view level.
+	 *
+	 * @param   integer   $id  View level identifier
+	 *
+	 * @return  boolean
+	 */
+	public function hasViewLevel($id)
+	{
+		return $this->viewLevels()->has($id);
+	}
+
+	/**
+	 * Check if this entity has associated view levels.
+	 *
+	 * @return  boolean
+	 */
+	public function hasViewLevels()
+	{
+		return !$this->viewLevels()->isEmpty();
+	}
+
+	/**
+	 * Load associated view levels.
+	 *
+	 * @return  Collection
+	 */
+	abstract protected function loadViewLevels();
+}

--- a/extensions/libraries/joomla_entity/src/Users/User.php
+++ b/extensions/libraries/joomla_entity/src/Users/User.php
@@ -13,10 +13,12 @@ defined('_JEXEC') || die;
 use Joomla\Registry\Registry;
 use Phproberto\Joomla\Entity\Collection;
 use Phproberto\Joomla\Entity\ComponentEntity;
-use Phproberto\Joomla\Entity\Acl\Contracts\Aclable;
+use Phproberto\Joomla\Entity\Users\ViewLevel;
 use Phproberto\Joomla\Entity\Acl\Traits\HasAcl;
+use Phproberto\Joomla\Entity\Acl\Contracts\Aclable;
 use Phproberto\Joomla\Entity\Core\Traits\HasParams;
 use Phproberto\Joomla\Entity\Users\Traits\HasUserGroups;
+use Phproberto\Joomla\Entity\Users\Traits\HasViewLevels;
 
 /**
  * User entity.
@@ -25,7 +27,7 @@ use Phproberto\Joomla\Entity\Users\Traits\HasUserGroups;
  */
 class User extends ComponentEntity implements Aclable
 {
-	use HasAcl, HasParams, HasUserGroups;
+	use HasAcl, HasParams, HasUserGroups, HasViewLevels;
 
 	/**
 	 * Is this user root/super user?
@@ -244,6 +246,25 @@ class User extends ComponentEntity implements Aclable
 		}
 
 		return $userGroups;
+	}
+
+	/**
+	 * Load associated view levels.
+	 *
+	 * @return  Collection
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function loadViewLevels()
+	{
+		$viewLevels = new Collection;
+
+		foreach ($this->getAuthorisedViewLevels() as $id)
+		{
+			$viewLevels->add(ViewLevel::find($id));
+		}
+
+		return $viewLevels;
 	}
 
 	/**

--- a/extensions/libraries/joomla_entity/src/Users/ViewLevel.php
+++ b/extensions/libraries/joomla_entity/src/Users/ViewLevel.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Joomla! entity library.
+ *
+ * @copyright  Copyright (C) 2017 Roberto Segura López, Inc. All rights reserved.
+ * @license    See COPYING.txt
+ */
+
+namespace Phproberto\Joomla\Entity\Users;
+
+defined('_JEXEC') || die;
+
+use Phproberto\Joomla\Entity\ComponentEntity;
+
+/**
+ * ViewLevel entity.
+ *
+ * @since   __DEPLOY_VERSION__
+ */
+class ViewLevel extends ComponentEntity
+{
+	/**
+	 * Get a table instance. Defauts to \JTableUser.
+	 *
+	 * @param   string  $name     Table name. Optional.
+	 * @param   string  $prefix   Class prefix. Optional.
+	 * @param   array   $options  Configuration array for the table. Optional.
+	 *
+	 * @return  \JTable
+	 *
+	 * @throws  \InvalidArgumentException
+	 */
+	public function table($name = '', $prefix = null, $options = array())
+	{
+		$name   = $name ?: 'ViewLevel';
+		$prefix = $prefix ?: 'JTable';
+
+		return parent::table($name, $prefix, $options);
+	}
+}

--- a/extensions/libraries/joomla_entity/src/Users/ViewLevel.php
+++ b/extensions/libraries/joomla_entity/src/Users/ViewLevel.php
@@ -10,7 +10,9 @@ namespace Phproberto\Joomla\Entity\Users;
 
 defined('_JEXEC') || die;
 
+use Phproberto\Joomla\Entity\Collection;
 use Phproberto\Joomla\Entity\ComponentEntity;
+use Phproberto\Joomla\Entity\Users\Traits\HasUserGroups;
 
 /**
  * ViewLevel entity.
@@ -19,6 +21,8 @@ use Phproberto\Joomla\Entity\ComponentEntity;
  */
 class ViewLevel extends ComponentEntity
 {
+	use HasUserGroups;
+
 	/**
 	 * Get a table instance. Defauts to \JTableUser.
 	 *
@@ -36,5 +40,34 @@ class ViewLevel extends ComponentEntity
 		$prefix = $prefix ?: 'JTable';
 
 		return parent::table($name, $prefix, $options);
+	}
+
+	/**
+	 * Load associated user groups from DB.
+	 *
+	 * @return  Collection
+	 */
+	protected function loadUserGroups()
+	{
+		$userGroups = new Collection;
+
+		if (!$this->has('rules'))
+		{
+			return $userGroups;
+		}
+
+		$rules = $this->get('rules');
+		$ids = array_unique(
+			array_filter(
+				empty($rules) ? [] : json_decode($rules)
+			)
+		);
+
+		foreach ($ids as $id)
+		{
+			$userGroups->add(UserGroup::find($id));
+		}
+
+		return $userGroups;
 	}
 }

--- a/tests/Unit/Users/Traits/HasViewLevelsTest.php
+++ b/tests/Unit/Users/Traits/HasViewLevelsTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Joomla! entity library.
+ *
+ * @copyright  Copyright (C) 2017 Roberto Segura López, Inc. All rights reserved.
+ * @license    See COPYING.txt
+ */
+
+namespace Phproberto\Joomla\Entity\Tests\Unit\Users\Traits;
+
+use Phproberto\Joomla\Entity\Collection;
+use Phproberto\Joomla\Entity\Users\ViewLevel;
+use Phproberto\Joomla\Entity\Tests\Unit\Users\Traits\Stubs\EntityWithViewLevels;
+
+/**
+ * HasViewLevels trait tests.
+ *
+ * @since   __DEPLOY_VERSION__
+ */
+class HasViewLevelsTest extends \PHPUnit\Framework\TestCase
+{
+	/**
+	 * clearViewLevels clears viewLevels property.
+	 *
+	 * @return  void
+	 */
+	public function testClearViewLevelsClearsViewLevelsProperty()
+	{
+		$entity = new EntityWithViewLevels;
+
+		$reflection = new \ReflectionClass($entity);
+
+		$viewLevelsProperty = $reflection->getProperty('viewLevels');
+		$viewLevelsProperty->setAccessible(true);
+
+		$this->assertSame(null, $viewLevelsProperty->getValue($entity));
+
+		$viewLevels = new Collection(array(ViewLevel::find(333)));
+
+		$viewLevelsProperty->setValue($entity, $viewLevels);
+
+		$this->assertSame($viewLevels, $viewLevelsProperty->getValue($entity));
+
+		$entity->clearViewLevels();
+
+		$this->assertSame(null, $viewLevelsProperty->getValue($entity));
+	}
+
+	/**
+	 * viewLevels returns cached data.
+	 *
+	 * @return  void
+	 */
+	public function testviewLevelsReturnsCachedData()
+	{
+		$entity = new EntityWithViewLevels;
+
+		$reflection = new \ReflectionClass($entity);
+
+		$viewLevelsProperty = $reflection->getProperty('viewLevels');
+		$viewLevelsProperty->setAccessible(true);
+
+		$this->assertSame(null, $viewLevelsProperty->getValue($entity));
+
+		$viewLevels = new Collection(array(ViewLevel::find(333)));
+
+		$viewLevelsProperty->setValue($entity, $viewLevels);
+
+		$this->assertSame($viewLevels, $entity->viewLevels());
+	}
+
+	/**
+	 * viewLevels returns loadViewLevels result if not cached.
+	 *
+	 * @return  void
+	 */
+	public function testViewLevelsReturnsLoadViewLevelsResultIfNotCached()
+	{
+		$expectedViewLevels = new Collection(
+			array(
+				ViewLevel::find(333),
+				ViewLevel::find(666)
+			)
+		);
+
+		$entity = new EntityWithViewLevels;
+		$entity->loadableViewLevels = $expectedViewLevels;
+
+		$this->assertSame($expectedViewLevels, $entity->viewLevels());
+	}
+
+	/**
+	 * hasViewLevel returns correct value.
+	 *
+	 * @return  void
+	 */
+	public function testHasViewLevelReturnsCorrectValue()
+	{
+		$entity = new EntityWithViewLevels;
+		$entity->loadableViewLevels = new Collection(
+			array(
+				ViewLevel::find(666),
+				ViewLevel::find(999)
+			)
+		);
+
+		$this->assertTrue($entity->hasViewLevel(666));
+		$this->assertFalse($entity->hasViewLevel(333));
+		$this->assertTrue($entity->hasViewLevel(999));
+	}
+
+	/**
+	 * hasViewLevels returns correct value.
+	 *
+	 * @return  void
+	 */
+	public function testHasViewLevelsReturnsCorrectValue()
+	{
+		$entity = new EntityWithViewLevels;
+		$entity->loadableViewLevels = new Collection(
+			array(
+				ViewLevel::find(333),
+				ViewLevel::find(666)
+			)
+		);
+
+		$this->assertTrue($entity->hasViewLevels());
+
+		$entity = new EntityWithViewLevels;
+		$entity->loadableViewLevels = new Collection;
+
+		$this->assertFalse($entity->hasViewLevels());
+	}
+}

--- a/tests/Unit/Users/Traits/Stubs/EntityWithViewLevels.php
+++ b/tests/Unit/Users/Traits/Stubs/EntityWithViewLevels.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Joomla! entity library.
+ *
+ * @copyright  Copyright (C) 2017 Roberto Segura López, Inc. All rights reserved.
+ * @license    See COPYING.txt
+ */
+
+namespace Phproberto\Joomla\Entity\Tests\Unit\Users\Traits\Stubs;
+
+use Phproberto\Joomla\Entity\Entity;
+use Phproberto\Joomla\Entity\Collection;
+use Phproberto\Joomla\Entity\Users\Traits\HasViewLevels;
+
+/**
+ * Sample class to test HasViewLevels trait.
+ *
+ * @since  __DEPLOY_VERSION__
+ *
+ * @codeCoverageIgnore
+ */
+class EntityWithViewLevels extends Entity
+{
+	use HasViewLevels;
+
+	/**
+	 * Expected loadViewLevels result.
+	 *
+	 * @var  Collection
+	 */
+	public $loadableViewLevels;
+
+	/**
+	 * Load associated view levels.
+	 *
+	 * @return  Collection
+	 */
+	protected function loadViewLevels()
+	{
+		return null === $this->loadableViewLevels ? new Collection : $this->loadableViewLevels;
+	}
+}

--- a/tests/Unit/Users/UserTest.php
+++ b/tests/Unit/Users/UserTest.php
@@ -65,6 +65,7 @@ class UserTest extends \TestCaseDatabase
 		$dataSet->addTable('jos_users', JPATH_TEST_DATABASE . '/jos_users.csv');
 		$dataSet->addTable('jos_usergroups', JPATH_TEST_DATABASE . '/jos_usergroups.csv');
 		$dataSet->addTable('jos_user_usergroup_map', JPATH_TEST_DATABASE . '/jos_user_usergroup_map.csv');
+		$dataSet->addTable('jos_viewlevels', JPATH_TEST_DATABASE . '/jos_viewlevels.csv');
 
 		return $dataSet;
 	}
@@ -615,5 +616,29 @@ class UserTest extends \TestCaseDatabase
 		$user = new User;
 
 		$this->assertInstanceOf('JTableUser', $user->table());
+	}
+
+	/**
+	 * @test
+	 *
+	 * @return void
+	 */
+	public function viewLevelsReturnsExpectedCollection()
+	{
+		$user = new User;
+		$viewLevels = $user->viewLevels();
+
+		$this->assertInstanceOf(Collection::class, $viewLevels);
+		$this->assertSame([1], $viewLevels->ids());
+
+		$user = $this->getMockBuilder(User::class)
+			->setMethods(array('getAuthorisedViewLevels'))
+			->getMock();
+
+		$user->expects($this->once())
+			->method('getAuthorisedViewLevels')
+			->willReturn([2,8]);
+
+		$this->assertSame([2,8], $user->viewLevels()->ids());
 	}
 }

--- a/tests/Unit/Users/ViewLevelTest.php
+++ b/tests/Unit/Users/ViewLevelTest.php
@@ -9,6 +9,7 @@
 namespace Phproberto\Joomla\Entity\Tests\Unit\Users;
 
 use Joomla\CMS\Factory;
+use Phproberto\Joomla\Entity\Collection;
 use Phproberto\Joomla\Entity\Users\ViewLevel;
 
 /**
@@ -68,7 +69,7 @@ class ViewLevelTest extends \TestCaseDatabase
 		Factory::$config      = $this->getMockConfig();
 		Factory::$application = $this->getMockCmsApp();
 
-		$this->entity = ViewLevel::find(1);
+		$this->entity = ViewLevel::find(3);
 	}
 
 	/**
@@ -95,5 +96,46 @@ class ViewLevelTest extends \TestCaseDatabase
 		$this->restoreFactoryState();
 
 		parent::tearDown();
+	}
+
+	/**
+	 * @test
+	 *
+	 * @return void
+	 */
+	public function userGroupsReturnsEmptyCollectionsForEmptyRules()
+	{
+		$entity = new ViewLevel;
+		$userGroups = $entity->userGroups();
+
+		$this->assertInstanceOf(Collection::class, $userGroups);
+
+		$entity = new ViewLevel;
+		$entity->bind(['id' => 333, 'title' => 'Unexisting1', 'rules' => '']);
+
+		$this->assertSame([], $entity->userGroups()->ids());
+
+		$entity = new ViewLevel;
+		$entity->bind(['id' => 333, 'title' => 'Unexisting2', 'rules' => '[2,4]']);
+
+		$this->assertSame([2,4], $entity->userGroups()->ids());
+
+		$entity = new ViewLevel;
+		$entity->bind(['id' => 222, 'title' => 'Unexisting2', 'rules' => null]);
+
+		$this->assertSame([], $entity->userGroups()->ids());
+	}
+
+	/**
+	 * @test
+	 *
+	 * @return void
+	 */
+	public function userGroupsReturnsExpectedUserGroups()
+	{
+		$userGroups = $this->entity->userGroups();
+
+		$this->assertInstanceOf(Collection::class, $userGroups);
+		$this->assertSame(3, $userGroups->count());
 	}
 }

--- a/tests/Unit/Users/ViewLevelTest.php
+++ b/tests/Unit/Users/ViewLevelTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Joomla! entity library.
+ *
+ * @copyright  Copyright (C) 2017 Roberto Segura López, Inc. All rights reserved.
+ * @license    See COPYING.txt
+ */
+
+namespace Phproberto\Joomla\Entity\Tests\Unit\Users;
+
+use Joomla\CMS\Factory;
+use Phproberto\Joomla\Entity\Users\ViewLevel;
+
+/**
+ * ViewLevel entity tests.
+ *
+ * @since   __DEPLOY_VERSION__
+ */
+class ViewLevelTest extends \TestCaseDatabase
+{
+	/**
+	 * Preloaded entity for tests.
+	 *
+	 * @var  ViewLevel
+	 */
+	private $entity;
+
+	/**
+	 * Gets the data set to be loaded into the database during setup
+	 *
+	 * @return  \PHPUnit_Extensions_Database_DataSet_CsvDataSet
+	 */
+	protected function getDataSet()
+	{
+		$dataSet = new \PHPUnit_Extensions_Database_DataSet_CsvDataSet(',', "'", '\\');
+		$dataSet->addTable('jos_viewlevels', JPATH_TEST_DATABASE . '/jos_viewlevels.csv');
+
+		return $dataSet;
+	}
+
+	/**
+	 * @test
+	 *
+	 * @return void
+	 */
+	public function loadWorks()
+	{
+		$data = $this->entity->all();
+
+		$this->assertTrue(is_array($data));
+		$this->assertTrue($this->entity->isLoaded());
+		$this->assertNotSame(0, count($data));
+	}
+
+	/**
+	 * Sets up the fixture, for example, opens a network connection.
+	 * This method is called before a test is executed.
+	 *
+	 * @return  void
+	 */
+	protected function setUp()
+	{
+		parent::setUp();
+
+		$this->saveFactoryState();
+
+		Factory::$session     = $this->getMockSession();
+		Factory::$config      = $this->getMockConfig();
+		Factory::$application = $this->getMockCmsApp();
+
+		$this->entity = ViewLevel::find(1);
+	}
+
+	/**
+	 * @test
+	 *
+	 * @return  void
+	 */
+	public function tableReturnsExpectedInstances()
+	{
+		$this->assertInstanceOf(\Joomla\CMS\Table\ViewLevel::class, $this->entity->table());
+		$this->assertInstanceOf(\Joomla\CMS\Table\User::class, $this->entity->table('User', 'JTable'));
+	}
+
+	/**
+	 * Tears down the fixture, for example, closes a network connection.
+	 * This method is called after a test is executed.
+	 *
+	 * @return  void
+	 */
+	protected function tearDown()
+	{
+		ViewLevel::clearAll();
+
+		$this->restoreFactoryState();
+
+		parent::tearDown();
+	}
+}


### PR DESCRIPTION
This introduces `ViewLevel` entity.

### Examples

**View level usage:**

```php
$viewLevel = ViewLevel::find(1);

// This will echo something like: Public
echo $viewLevel->get('title');
```

**View level user groups:**

```php
$viewLevel = ViewLevel::find(1);

// This will return a collection of UserGroups in this view level.
$userGroups = $viewLevel->userGroups();

// Check if a view level has user groups
if ($viewLevel->hasUserGroups())
{
    // Do something
}

// Check if a view level has an user group
if ($viewLevel->hasUserGroup(1))
{
    // Do something
}
```

**User view levels:**

```php
$user = User::find(42);

// This returns a collection of ViewLevel entities
$viewLevels = $user->viewLevels();

// Check if user has a specific view level
if ($user->hasViewLevel(1))
{
    // Do something
}
```